### PR TITLE
Use IO.popen to access copy command.

### DIFF
--- a/mrblib/emoji-cli.rb
+++ b/mrblib/emoji-cli.rb
@@ -38,9 +38,12 @@ end
 def copy emoji
   os = `uname`.strip
   cmd = if os == "Darwin"
-    "echo '#{emoji}' | tr -d '\n' | pbcopy"
+    "pbcopy"
   else
-    "echo '#{emoji}' | tr -d '\n' | xclip -i"
+    "xclip -i"
   end
-  `#{cmd}`
+
+  IO.popen(cmd, "w") do |selection|
+    selection.print emoji
+  end
 end


### PR DESCRIPTION
I was investigating the need to use `echo -e` to process
backslash-escaped characters on Linux and was having a ton of trouble
getting the `` command to put the emoji character through the pipe in a
way that it be interpreted correctly. I also ran into the "hanging"
issue described in bintest/emoji-cli.rb#14 which I tried to strace

```
...output abriged...
write(1, "Running command /usr/bin/echo -n"..., 51Running command /usr/bin/echo -ne '🎈' | xclip -i) = 51
write(1, "\n", 1)                       = 1
pipe2([3, 4], O_CLOEXEC)                = 0
clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7fd0005409d0) = 15261
close(4)                                = 0
fcntl(3, F_SETFD, 0)                    = 0
fstat(3, {st_mode=S_IFIFO|0600, st_size=0, ...}) = 0
read(3, 0xacb940, 4096)                 = ? ERESTARTSYS (To be restarted if SA_RESTART is set)
--- SIGCHLD {si_signo=SIGCHLD, si_code=CLD_EXITED, si_pid=15261, si_uid=1000, si_status=0, si_utime=0, si_stime=0} ---
read(3, "",
```

When using xclip it looks like parent-readable end of the pipe (file descriptor 3) is not being closed which could mean that xclip is potentially still waiting for more data from the parent-writeable end of the pipe (file descriptor 4) which is weird because that was closed above.

I think this must have something to do with how backticks function in mruby: so near as I can tell the shell commands are processed with `sh -c BACKTICK_CONTENTS` but that should still result in a successfully piped emoji character unless sh, echo, or xclip isn't properly reading it as unicode data. 

I still don't know exactly _why_ the echo command wasn't working on Linux and I'm a bit too unfamiliar with mruby to really dig into it as I am able to run `sh -c "echo -ne 🐧 | xclip -i"` and have it copy the penguin emoji to my selection.

Since the mruby-io mrbgem was already present, I rewrote the copy method to use IO.popen rather than backticks to directly write the emoji character to the standard input of the copy command's process.

I haven't yet been able to test this for Mac OS but we can always make it a Linux specific change if it doesn't work or the the backtick of echo is preferred.

cc @muan for review and Mac OS testing.

We might also be able to revisit the tests now that the hang has been resolved.
